### PR TITLE
pass headless input arg into the R6 initialization

### DIFF
--- a/R/launch.R
+++ b/R/launch.R
@@ -135,7 +135,7 @@ CrrryOnPage <- R6::R6Class(
       chrome_bin = Sys.getenv("HEADLESS_CHROME"),
       chrome_port = 9222L,
       url,
-      headless = TRUE,
+      headless = headless,
       ...
     ){
       private$chrome <- crrri::Chrome$new(
@@ -213,6 +213,7 @@ CrrryProc <- R6::R6Class(
       private$chrome <- crrri::Chrome$new(
         chrome_bin,
         debug_port = chrome_port,
+        headless = headless,
         ...
       )
       private$client <- crrri::hold(


### PR DESCRIPTION
headless argument is not currently passed to the R6 object internally on initialization